### PR TITLE
Pass all arguments to wayfarer router

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,16 +33,17 @@ function Nanorouter (opts) {
     router.on(routename, listener)
   }
 
-  function emit (route) {
+  function emit () {
+    var route = arguments[0]
     if (!curry) {
-      return router(route)
+      return router.apply(this, arguments)
     } else {
       route = pathname(route, isLocalFile)
       if (route === prevRoute) {
         return prevCallback()
       } else {
         prevRoute = route
-        prevCallback = router(route)
+        prevCallback = router.apply(this, arguments)
         return prevCallback()
       }
     }


### PR DESCRIPTION
Hey :)

Not sure if you actually want to add this. But in choo v5 you use the router with multiple arguments like `router(createLocation(), state, emit)`, but since they are not passed to wayfarer, they never end up in the event.