### PR TITLE
Add .match(router) method that returns a route without invoking a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ in `opts.default` will be called. If no default handler matches, an error
 will be thrown. Results return from the called handler will be returned from
 this function.
 
+### `matchedRoute = router.match(route)`
+Matches a route and returns an object. The returned object contains the properties `{cb, params, route}`. This method does not invoke the callback of a route. If no route matches, the route specified in `opts.default` will be returned. If no default route matches, an error will be thrown.
+
 Note that `router()` does not affect browser history. If you would like to
 add or modify history entries when you change routes, you should use
 [`history.pushState()` and `history.replaceState()`](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries)

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Nanorouter (opts) {
 
   emit.router = router
   emit.on = on
+  emit.match = match
   return emit
 
   function on (routename, listener) {
@@ -47,6 +48,11 @@ function Nanorouter (opts) {
         return prevCallback()
       }
     }
+  }
+
+  function match (route) {
+    route = pathname(route, isLocalFile)
+    return router.match(route)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "standard && npm run deps"
   },
   "dependencies": {
-    "wayfarer": "^6.5.0"
+    "wayfarer": "^6.6.3"
   },
   "devDependencies": {
     "dependency-check": "^2.8.0",


### PR DESCRIPTION
This pull request contains a first part of https://github.com/choojs/nanorouter/pull/8 without introducing any big changes. We'll first need to release https://github.com/yoshuawuyts/wayfarer/pull/64 to get that working with the published module.