### PR TITLE
Fix routing inconsistencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ function Nanorouter (opts) {
   }
 
   function emit (route) {
+    route = pathname(route, isLocalFile)
     if (!curry) {
       return router(route)
     } else {
-      route = pathname(route, isLocalFile)
       if (route === prevRoute) {
         return prevCallback()
       } else {


### PR DESCRIPTION
Currently the normalization of the route only happens when the `curry` option is in use.
With this commit, that behavior is also applied when that's disabled.

This might be a breaking change in which case we could ship it with the removal of the `curry` option. But sadly I have no idea what that normalization is used for.
Therefore I also can't write tests 😢 .


edit: I just found one use case for that normalization, so it looks like this is a bug... but theoretically still breaking. Here's a choo example that uses `#active` as route:
https://github.com/choojs/choo/blob/master/example/index.js#L14
```js
app.route('/', require('./view'))
app.route('#active', require('./view'))
app.route('#completed', require('./view'))
app.route('*', require('./view'))
```