### PR TITLE
Remove curry option and migrate to prototypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "start": "node .",
-    "test": "standard && npm run deps"
+    "test": "standard && npm run deps && tape test.js"
   },
   "dependencies": {
     "wayfarer": "^6.6.3"
@@ -15,7 +15,7 @@
     "dependency-check": "^2.8.0",
     "nyc": "^10.1.2",
     "standard": "^9.0.1",
-    "tape": "^4.6.3"
+    "tape": "^4.8.0"
   },
   "keywords": [
     "router",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,104 @@
+var tape = require('tape')
+var nanorouter = require('./')
+function noop () {}
+
+tape('router', function (t) {
+  t.test('.on() throws type errors for invalid parameters', function (t) {
+    t.plan(2)
+    var r = nanorouter()
+    t.throws(r.on.bind(r, 123), /string/, 'route must be a string')
+    t.throws(r.on.bind(r, '/', 123), /function/, 'handler must be a function')
+  })
+
+  t.test('.emit() throws if if no route is found', function (t) {
+    t.plan(2)
+    var r = nanorouter()
+    t.throws(r.emit.bind(r, '/'), /route '\/' did not match/)
+    t.throws(r.emit.bind(r, '/test'), /route '\/test' did not match/)
+  })
+
+  t.test('.emit() should match a path', function (t) {
+    t.plan(2)
+    var r = nanorouter()
+    r.on('/foo', function () {
+      t.pass('called')
+    })
+    r.on('/foo/bar', function () {
+      t.pass('called')
+    })
+    r.emit('/foo')
+    r.emit('/foo/bar')
+  })
+
+  t.test('.emit() should fallback to a default path', function (t) {
+    t.plan(2)
+    var r1 = nanorouter()
+    var r2 = nanorouter({default: '/custom-error'})
+    r1.on('/404', function () {
+      t.pass('default called')
+    })
+    r2.on('/custom-error', function () {
+      t.pass('custom error called')
+    })
+    r1.emit('/nope')
+    r2.emit('/custom-error')
+  })
+
+  t.test('.emit() should match partials', function (t) {
+    t.plan(2)
+    var r = nanorouter()
+    r.on('/:foo/:bar', function (param) {
+      t.equal(param.foo, 'baz', 'first param matched')
+      t.equal(param.bar, 'qux', 'second param matched')
+    })
+    r.emit('/baz/qux')
+  })
+
+  t.test('.emit() should match a hash', function (t) {
+    t.plan(1)
+    var r = nanorouter()
+    r.on('#test', function () {
+      t.pass('called')
+    })
+    r.emit('#test')
+  })
+
+  t.test('.match() should match a path', function (t) {
+    t.plan(2)
+    var r = nanorouter()
+    r.on('/foo', function () {
+      t.fail('accidentally called')
+    })
+    r.on('/foo/bar', function () {
+      t.fail('accidentally called')
+    })
+    t.ok(r.match('/foo'))
+    t.ok(r.match('/foo/bar'))
+  })
+
+  t.test('.match() returns a an object with a handler', function (t) {
+    t.plan(1)
+    var r = nanorouter()
+    r.on('/:foo/:bar', function () {
+      t.pass('called')
+    })
+    r.match('/baz/qux').cb()
+  })
+
+  t.test('.match() should match partials', function (t) {
+    t.plan(3)
+    var r = nanorouter()
+    r.on('/:foo/:bar', noop)
+    var matched = r.match('/baz/qux')
+    t.equal(matched.params.foo, 'baz')
+    t.equal(matched.params.bar, 'qux')
+    t.equal(Object.keys(matched.params).length, 2)
+  })
+
+  t.test('.match() returns a an object with a route property', function (t) {
+    t.plan(1)
+    var r = nanorouter()
+    r.on('/:foo/:bar', noop)
+    t.equal(r.match('/baz/qux').route, ':foo/:bar')
+  })
+})


### PR DESCRIPTION
The changes in here remove the curry option and migrate to prototypes as discussed in #12 and #6.
This pull request currently also includes a change done in #9. So we could do two releases (minor & major) or just a major one.

### Api changes
- The `curry` option got removed as mentioned in 
- We've migrated the api to prototypes, so the returned router function doesn't exist anymore. Please use `router.emit(path)` instead

```js
const router = require('nanorouter')({default: '/404'})

// Registers a handler to a specific route
router.on('/path', function (params) {
  return 'something'
})

// Executes a handler, passes `params` as first argument
// Returns the value of the executed handler
const returnValue = router.emit('/path')

// Returns a matched route, falls back to the default route or throws if nothing is found
router.match('/path')
```

### Migration from the old `curry`  option
The `curry` option was confusing to use and read. Therefore we removed that completely. 
Previously it was possible to use the `curry` option like that:
```js
const router = require('nanorouter')({curry: true})
router.on('/hello/:someparam', function (params) {
  return function () {
    return {hello: params.someparam}
  }
})

const returnvalue = router.emit('/something/world')
// returnvalue === '{"hello": "world"}'
```

Now that this option doesn't exist anymore, we advise you to migrate to the `.match()` method as it's much more flexible in case you'll need more advanced parameters.
```js
const router = require('nanorouter')()
router.on('/hello/:someparam', function (params) {
  return {hello: params.someparam}
})

const route = router.match('/something/world')
const returnvalue = route.cb(route.params)
// returnvalue === '{"hello": "world"}'
```

if you won't have time to migrate your code and want to keep the old behavior, just wrap everything in a self-executing function.
```js
router.on('/hello/:someparam', function (params) {
  return (function () {
    return {hello: params.someparam}
  })()
})

// or wrap the registration of the handler in a function
const router = require('nanorouter')()
function onRoute (path, handler) {
  router.on(path, function (params) {
    var modifiedParameters = {params: params}
    return handler(modifiedParameters)
  })
}

