### PR TITLE
Support matching UTF-8 route strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,5 +50,5 @@ Nanorouter.prototype.match = function (routename) {
 function pathname (routename, isElectron) {
   if (isElectron) routename = routename.replace(stripElectron, '')
   else routename = routename.replace(prefix, '')
-  return routename.replace(suffix, '').replace(normalize, '/')
+  return decodeURI(routename.replace(suffix, '').replace(normalize, '/'))
 }

--- a/test.js
+++ b/test.js
@@ -63,6 +63,15 @@ tape('router', function (t) {
     r.emit('#test')
   })
 
+  t.test('.match() should match a path with utf-8 characters', function (t) {
+    t.plan(1)
+    var r = nanorouter()
+    r.on('/foobær', function () {
+      t.fail('accidentally called')
+    })
+    t.ok(r.match(encodeURI('/foobær')))
+  })
+
   t.test('.match() should match a path', function (t) {
     t.plan(2)
     var r = nanorouter()


### PR DESCRIPTION
Seeing how browsers encode seemingly regular looking utf-8 characters in the url bar to a `encodeURI` packaged string on `window.location.pathname`, it seems like a good idea to use `decodeURI` it to enable string matching on plain utf-8 string routes.

If it's thought to be a better convention to use `encodeURI` on the `on` function call – LMK.